### PR TITLE
Update to supporter Vue 3

### DIFF
--- a/dist/vue-cancan.js
+++ b/dist/vue-cancan.js
@@ -29,11 +29,11 @@ exports.default = {
 
     this.rules = options.rules;
 
-    Vue.globalProperties.$can = function (action, subject) {
+    Vue.config.globalProperties.$can = function (action, subject) {
       return _this.$can(action, subject);
     };
 
-    Vue.globalProperties.setRules = function (rules) {
+    Vue.config.globalProperties.setRules = function (rules) {
       return _this.setRules(rules);
     };
 

--- a/dist/vue-cancan.js
+++ b/dist/vue-cancan.js
@@ -29,11 +29,11 @@ exports.default = {
 
     this.rules = options.rules;
 
-    Vue.prototype.$can = function (action, subject) {
+    Vue.globalProperties.$can = function (action, subject) {
       return _this.$can(action, subject);
     };
 
-    Vue.prototype.setRules = function (rules) {
+    Vue.globalProperties.setRules = function (rules) {
       return _this.setRules(rules);
     };
 

--- a/src/vue-cancan.js
+++ b/src/vue-cancan.js
@@ -25,9 +25,9 @@ export default {
   install(Vue, options) {
     this.rules = options.rules;
 
-    Vue.globalProperties.$can = (action, subject) => this.$can(action, subject);
+    Vue.config.globalProperties.$can = (action, subject) => this.$can(action, subject);
 
-    Vue.globalProperties.setRules = (rules) => this.setRules(rules);
+    Vue.config.globalProperties.setRules = (rules) => this.setRules(rules);
 
     Vue.directive('can', {
       inserted: (el, binding) => {

--- a/src/vue-cancan.js
+++ b/src/vue-cancan.js
@@ -25,9 +25,9 @@ export default {
   install(Vue, options) {
     this.rules = options.rules;
 
-    Vue.prototype.$can = (action, subject) => this.$can(action, subject);
+    Vue.globalProperties.$can = (action, subject) => this.$can(action, subject);
 
-    Vue.prototype.setRules = (rules) => this.setRules(rules);
+    Vue.globalProperties.setRules = (rules) => this.setRules(rules);
 
     Vue.directive('can', {
       inserted: (el, binding) => {


### PR DESCRIPTION
Vue.prototype Replaced by config.globalProperties.

In Vue 2, Vue.prototype was commonly used to add properties that would be accessible in all components.
The equivalent in Vue 3 is config.globalProperties. These properties will be copied across as part of instantiating a component.
